### PR TITLE
[FEATURE] 모바일뷰 오버레이 라우트 설정

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,26 +1,38 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
-import { usePathname } from 'next/navigation';
+import { useIsMobile } from '@/hooks/useIsMobile';
+
+// 오버레이 경로 패턴 정의
+// 필요 시 패턴 추가
+const OVERLAY_ROUTES = [
+  /^\/teampsylog\/head\/[^/]+$/, // /teampsylog/head/:uuid
+  /^\/question\/[^/]+$/, // /question/:uuid
+];
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
-  // 'use client' 삭제하고 헤더에서 사용할 수 있도록 수정
   const pathname = usePathname();
-  const shouldHideHeader = pathname.includes('/mobile');
+  const isMobile = useIsMobile();
 
+  const shouldShowOverlay = isMobile && OVERLAY_ROUTES.some((pattern) => pattern.test(pathname));
+
+  if (shouldShowOverlay) {
+    return (
+      <main className="fixed inset-0 z-50 flex">
+        <div className="w-full overflow-y-auto bg-white px-4">{children}</div>
+      </main>
+    );
+  }
+
+  // 기본 레이아웃
   return (
     <>
-      {shouldHideHeader ? (
-        <>{children}</>
-      ) : (
-        <>
-          <Header />
-          <main className="desktop:max-w-[1024px] desktop:px-10 desktop:min-h-[calc(100vh-65px)] mx-auto w-full max-w-[640px] px-4">
-            {children}
-          </main>
-        </>
-      )}
+      <Header />
+      <main className="desktop:max-w-[1024px] desktop:px-10 desktop:min-h-[calc(100vh-65px)] mx-auto w-full max-w-[640px] px-4">
+        {children}
+      </main>
       <Footer />
     </>
   );

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,37 +1,13 @@
-'use client';
-
-import { usePathname } from 'next/navigation';
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
-import { useIsMobile } from '@/hooks/useIsMobile';
-
-// 오버레이 경로 패턴 정의
-// 필요 시 패턴 추가
-const OVERLAY_ROUTES = [
-  /^\/teampsylog\/head\/[^/]+$/, // /teampsylog/head/:uuid
-  /^\/question\/[^/]+$/, // /question/:uuid
-];
+import MobileOverlayWrapper from '@/components/layout/MobileOverlayWrapper';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const isMobile = useIsMobile();
-
-  const shouldShowOverlay = isMobile && OVERLAY_ROUTES.some((pattern) => pattern.test(pathname));
-
-  if (shouldShowOverlay) {
-    return (
-      <main className="fixed inset-0 z-50 flex">
-        <div className="w-full overflow-y-auto bg-white px-4">{children}</div>
-      </main>
-    );
-  }
-
-  // 기본 레이아웃
   return (
     <>
       <Header />
       <main className="desktop:max-w-[1024px] desktop:px-10 desktop:min-h-[calc(100vh-65px)] mx-auto w-full max-w-[640px] px-4">
-        {children}
+        <MobileOverlayWrapper>{children}</MobileOverlayWrapper>
       </main>
       <Footer />
     </>

--- a/src/components/common/MobileHeader.tsx
+++ b/src/components/common/MobileHeader.tsx
@@ -5,23 +5,41 @@ import { useRouter } from 'next/navigation';
 
 interface MobileHeaderProps {
   title: string;
+  progress?: number;
 }
 
-const MobileHeader = ({ title }: MobileHeaderProps) => {
+const MobileHeader = ({ title, progress }: MobileHeaderProps) => {
   const router = useRouter();
 
   return (
-    <header className="tablet:hidden mx-auto flex w-full max-w-[1024px] items-center border-b border-gray-300 py-3">
-      <div className="flex flex-1">
-        <button onClick={() => router.back()} className="flex items-center">
-          <Image src="/icons/header-arrow-left.svg" alt="back" width={30} height={30} />
-        </button>
-      </div>
-      <div className="flex flex-1 justify-center">
-        <span className="body-5 text-center">{title}</span>
-      </div>
-      <div className="flex-1"></div>
-    </header>
+    <>
+      <header className="tablet:hidden w-full">
+        <div className="mx-auto max-w-[1024px]">
+          <div className="-mx-4 flex items-center px-4 py-3">
+            <div className="flex flex-1">
+              <button onClick={() => router.back()} className="flex items-center">
+                <Image src="/icons/header-arrow-left.svg" alt="back" width={30} height={30} />
+              </button>
+            </div>
+            <div className="flex flex-1 justify-center">
+              <span className="body-5 text-center">{title}</span>
+            </div>
+            <div className="flex-1"></div>
+          </div>
+        </div>
+      </header>
+      {/* 진행 바 */}
+      {typeof progress === 'number' ? (
+        <div className="tablet:hidden -mx-4 h-[2px] bg-gray-300">
+          <div
+            className="bg-primary-500 h-full transition-all"
+            style={{ width: `${Math.max(0, Math.min(1, progress)) * 100}%` }}
+          />
+        </div>
+      ) : (
+        <div className="tablet:hidden -mx-4 h-px bg-gray-300" />
+      )}
+    </>
   );
 };
 

--- a/src/components/common/MobileHeader.tsx
+++ b/src/components/common/MobileHeader.tsx
@@ -11,11 +11,16 @@ const MobileHeader = ({ title }: MobileHeaderProps) => {
   const router = useRouter();
 
   return (
-    <header className="tablet:hidden mx-auto flex w-full max-w-[1024px] items-center py-3">
-      <button onClick={() => router.back()} className="mr-[29px] flex items-center">
-        <Image src="/icons/header-arrow-left.svg" alt="back" width={30} height={30} />
-      </button>
-      <span className="body-5 w-[171px] text-center">{title}</span>
+    <header className="tablet:hidden mx-auto flex w-full max-w-[1024px] items-center border-b border-gray-300 py-3">
+      <div className="flex flex-1">
+        <button onClick={() => router.back()} className="flex items-center">
+          <Image src="/icons/header-arrow-left.svg" alt="back" width={30} height={30} />
+        </button>
+      </div>
+      <div className="flex flex-1 justify-center">
+        <span className="body-5 text-center">{title}</span>
+      </div>
+      <div className="flex-1"></div>
     </header>
   );
 };

--- a/src/components/layout/MobileOverlayWrapper.tsx
+++ b/src/components/layout/MobileOverlayWrapper.tsx
@@ -23,7 +23,7 @@ function MobileOverlayWrapperContent({ children }: MobileOverlayWrapperProps) {
 
   if (shouldShowOverlay) {
     return (
-      <div className="fixed inset-0 z-50 flex">
+      <div className="max-desktop:flex fixed inset-0 z-50 hidden">
         <div className="w-full overflow-y-auto bg-white px-4">{children}</div>
       </div>
     );

--- a/src/components/layout/MobileOverlayWrapper.tsx
+++ b/src/components/layout/MobileOverlayWrapper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { usePathname } from 'next/navigation';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { ReactNode } from 'react';
@@ -14,7 +15,7 @@ interface MobileOverlayWrapperProps {
   children: ReactNode;
 }
 
-export default function MobileOverlayWrapper({ children }: MobileOverlayWrapperProps) {
+function MobileOverlayWrapperContent({ children }: MobileOverlayWrapperProps) {
   const pathname = usePathname();
   const isMobile = useIsMobile();
 
@@ -22,11 +23,19 @@ export default function MobileOverlayWrapper({ children }: MobileOverlayWrapperP
 
   if (shouldShowOverlay) {
     return (
-      <main className="fixed inset-0 z-50 flex">
+      <div className="fixed inset-0 z-50 flex">
         <div className="w-full overflow-y-auto bg-white px-4">{children}</div>
-      </main>
+      </div>
     );
   }
 
   return <>{children}</>;
+}
+
+export default function MobileOverlayWrapper({ children }: MobileOverlayWrapperProps) {
+  return (
+    <Suspense fallback={null}>
+      <MobileOverlayWrapperContent>{children}</MobileOverlayWrapperContent>
+    </Suspense>
+  );
 }

--- a/src/components/layout/MobileOverlayWrapper.tsx
+++ b/src/components/layout/MobileOverlayWrapper.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { ReactNode } from 'react';
+
+// 오버레이 경로 패턴 정의
+const OVERLAY_ROUTES = [
+  /^\/teampsylog\/head\/[^/]+$/, // /teampsylog/head/:uuid
+  /^\/question\/[^/]+$/, // /question/:uuid
+];
+
+interface MobileOverlayWrapperProps {
+  children: ReactNode;
+}
+
+export default function MobileOverlayWrapper({ children }: MobileOverlayWrapperProps) {
+  const pathname = usePathname();
+  const isMobile = useIsMobile();
+
+  const shouldShowOverlay = isMobile && OVERLAY_ROUTES.some((pattern) => pattern.test(pathname));
+
+  if (shouldShowOverlay) {
+    return (
+      <main className="fixed inset-0 z-50 flex">
+        <div className="w-full overflow-y-auto bg-white px-4">{children}</div>
+      </main>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 
 export function useIsMobile(breakpoint: number = 640) {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     const checkMobile = () => {
@@ -15,5 +15,5 @@ export function useIsMobile(breakpoint: number = 640) {
     return () => window.removeEventListener('resize', checkMobile);
   }, [breakpoint]);
 
-  return isMobile;
+  return isMobile ?? false;
 }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useIsMobile(breakpoint: number = 640) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

### 📌 관련 이슈번호

- Closed #109

---

### ✅ Key Changes

- 각 페이지 최상단에 <MobileHeader title="" /> 컴포넌트 추가
- `src/app/(main)/layout.tsx` 에서 해당 헤더가 존재하는 페이지 경로 작성 -> 따로 모바일용 경로 설정할 필요 X

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/cbe07962-2c0b-4850-b10f-bc26194df42c" />
---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 특정 경로에서 전체 화면 오버레이를 조건부로 표시하는 래퍼 추가
  * 화면 크기 감지를 위한 모바일 훅 추가

* **개선 사항**
  * 레이아웃에서 헤더는 항상 렌더링되며 콘텐츠가 오버레이 래퍼로 감싸짐
  * 모바일 헤더를 왼쪽 뒤로가기·중앙 제목·오른쪽 여백의 3단 구조로 재설계
  * 모바일 헤더에 선택적 진행률 표시(프로그레스 바) 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->